### PR TITLE
Add publish_batch

### DIFF
--- a/lib/gcpc/publisher.rb
+++ b/lib/gcpc/publisher.rb
@@ -37,6 +37,6 @@ module Gcpc
 
     extend Forwardable
 
-    def_delegators :@engine, :publish, :publish_async, :topic
+    def_delegators :@engine, :publish, :publish_batch, :publish_async, :topic
   end
 end

--- a/lib/gcpc/publisher/engine.rb
+++ b/lib/gcpc/publisher/engine.rb
@@ -1,11 +1,15 @@
+require "gcpc/publisher/engine/batch_engine"
+require "gcpc/publisher/engine/chained_interceptor"
+
 module Gcpc
   class Publisher
     class Engine
       # @param [Google::Cloud::Pubsub::Topic] topic
       # @param [<#publish>] interceptors
       def initialize(topic:, interceptors:)
-        @topic        = topic
-        @interceptors = interceptors.map { |i| (i.class == Class) ? i.new : i }
+        @topic       = topic
+        interceptors = interceptors.map { |i| (i.class == Class) ? i.new : i }
+        @interceptor = ChainedInterceptor.new(interceptors)
       end
 
       attr_reader :topic
@@ -16,38 +20,30 @@ module Gcpc
         d = data.dup
         a = attributes.dup
 
-        intercept!(@interceptors, d, a) do |dd, aa|
+        @interceptor.intercept!(d, a) do |dd, aa|
           do_publish(dd, aa)
         end
       end
 
+      # @param [Proc] block
+      def publish_batch(&block)
+        batch_engine = BatchEngine.new(topic: @topic, interceptor: @interceptor)
+        yield batch_engine
+        batch_engine.flush
+      end
+
+      # @param [String] data
+      # @param [Hash] attributes
       def publish_async(data, attributes = {}, &block)
         d = data.dup
         a = attributes.dup
 
-        intercept!(@interceptors, d, a) do |dd, aa|
+        @interceptor.intercept!(d, a) do |dd, aa|
           do_publish_async(dd, aa, &block)
         end
       end
 
     private
-
-      # @param [<#publish>] interceptors
-      # @param [String] data
-      # @param [Hash] attributes
-      # @param [Proc] block
-      def intercept!(interceptors, data, attributes, &block)
-        if interceptors.size == 0
-          return yield(data, attributes)
-        end
-
-        i    = interceptors.first
-        rest = interceptors[1..-1]
-
-        i.publish(data, attributes) do |d, a|
-          intercept!(rest, d, a, &block)
-        end
-      end
 
       # @param [String] data
       # @param [Hash] attributes

--- a/lib/gcpc/publisher/engine/batch_engine.rb
+++ b/lib/gcpc/publisher/engine/batch_engine.rb
@@ -1,0 +1,37 @@
+module Gcpc
+  class Publisher
+    class Engine
+      class BatchEngine
+        # @param [Google::Cloud::Pubsub::Topic] topic
+        # @param [Engine::ChainedInterceptor] interceptor
+        def initialize(topic:, interceptor:)
+          @topic       = topic
+          @interceptor = interceptor
+          @messages    = []  # Container of data and attributes
+        end
+
+        # Enqueue a message
+        #
+        # @param [String] data
+        # @param [Hash] attributes
+        def publish(data, attributes = {})
+          d = data.dup
+          a = attributes.dup
+
+          @interceptor.intercept!(d, a) do |dd, aa|
+            @messages << [dd, aa]
+          end
+        end
+
+        # Flush all enqueued messages
+        def flush
+          @topic.publish do |t|
+            @messages.each do |(data, attributes)|
+              t.publish data, attributes
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gcpc/publisher/engine/chained_interceptor.rb
+++ b/lib/gcpc/publisher/engine/chained_interceptor.rb
@@ -1,0 +1,38 @@
+module Gcpc
+  class Publisher
+    class Engine
+      class ChainedInterceptor
+        # @param [<#publish>] interceptors
+        def initialize(interceptors)
+          @interceptors = interceptors
+        end
+
+        # @param [String] data
+        # @param [Hash] attributes
+        # @param [Proc] block
+        def intercept!(data, attributes, &block)
+          do_intercept!(@interceptors, data, attributes, &block)
+        end
+
+      private
+
+        # @param [<#publish>] interceptors
+        # @param [String] data
+        # @param [Hash] attributes
+        # @param [Proc] block
+        def do_intercept!(interceptors, data, attributes, &block)
+          if interceptors.size == 0
+            return yield(data, attributes)
+          end
+
+          i    = interceptors.first
+          rest = interceptors[1..-1]
+
+          i.publish(data, attributes) do |d, a|
+            do_intercept!(rest, d, a, &block)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/gcpc_spec.rb
+++ b/spec/gcpc_spec.rb
@@ -59,6 +59,40 @@ describe Gcpc do
       subscriber_thread.join
     end
 
+    it "succeeds to publish_batch and subscribe messages" do
+      stub_handler = double(:stub_handler)
+      expect(stub_handler).to receive(:handle).once
+
+      subscriber = Gcpc::Subscriber.new(
+        project_id:    project_id,
+        subscription:  subscription_name,
+        emulator_host: "localhost:8085",
+      )
+      subscriber.handle(stub_handler)
+
+      # Start subscriber in another thread
+      subscriber_thread = Thread.new(subscriber) do |subscriber|
+        subscriber.run
+      end
+
+      publisher = Gcpc::Publisher.new(
+        project_id:    project_id,
+        topic:         topic_name,
+        emulator_host: emulator_host,
+      )
+      data = "message payload"
+      attributes = { publisher: "publisher-example" }
+      publisher.publish_batch do |t|
+        t.publish(data, attributes)
+      end
+
+      sleep 1  # Wait for publish / subscribe a message
+
+      # Stop the subscriber and its thread.
+      subscriber.stop
+      subscriber_thread.join
+    end
+
     it "succeeds to publish_async and subscribe messages" do
       stub_handler = double(:stub_handler)
       expect(stub_handler).to receive(:handle).once


### PR DESCRIPTION
## WHY
We sometimes want to use batch publishing feature.

cf. https://github.com/googleapis/google-cloud-ruby/blob/32cbf03c10f92a1545a4d2bb08cb09ea642b92bf/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb#L455-L466

## WHAT

Added `#publish_batch` method. By using this, multiple messages can be sent at the same time.

```ruby
publisher = Gcpc::Publisher.new(...)
r = publisher.publish_batch do |t|
  t.publish("data1")
  t.publish("data2")
  t.publish("data3")
end
expect(r.map(&:data)).to eq ["data1", "data2", "data3"]
```