### PR TITLE
Add explicit loading of forwardable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ jobs:
     - name: 'test with a emulator'
       before_install:
         # Start a Cloud Pub/Sub emulator. See https://cloud.google.com/pubsub/docs/emulator
-        - docker run -d -p 8085:8085 -it google/cloud-sdk:latest gcloud beta emulators pubsub start --host-port=0.0.0.0:8085
+        # We use `google/cloud-sdk:321.0.0` because we can't start pubsub with the latest.
+        - docker run -d -p 8085:8085 -it google/cloud-sdk:321.0.0 gcloud beta emulators pubsub start --host-port=0.0.0.0:8085
       script:
         - bundle exec rspec --tag emulator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 <!-- All changes (implementation, or doc changes) are worth noting. -->
 <!-- The changes listed above will go below when a new release is being prepared. -->
 
+- Add explicit loading of forwardable https://github.com/south37/gcpc/pull/10
+
 ## 0.0.6
 
 - Add test of interceptors https://github.com/south37/gcpc/pull/7

--- a/lib/gcpc/publisher.rb
+++ b/lib/gcpc/publisher.rb
@@ -1,3 +1,4 @@
+require "forwardable"
 require "gcpc/publisher/base_interceptor"
 require "gcpc/publisher/engine"
 require "gcpc/publisher/topic_client"

--- a/lib/gcpc/subscriber.rb
+++ b/lib/gcpc/subscriber.rb
@@ -1,3 +1,4 @@
+require "forwardable"
 require "gcpc/subscriber/base_handler"
 require "gcpc/subscriber/base_interceptor"
 require "gcpc/subscriber/default_logger"


### PR DESCRIPTION
## Why
The following error may occur while loading gcpc.

```ruby
Failure/Error: require "gcpc"
NameError:
  uninitialized constant Gcpc::Publisher::Forwardable
# ./vendor/bundle/ruby/2.6.0/gems/gcpc-0.0.4/lib/gcpc/publisher.rb:38:in `<class:Publisher>'
```

## What
Added the explicit loading of `forwardable`.