### PR TITLE
Add ruby 2.7 as a test target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.6.2
+  - 2.6.6
+  - 2.7.3
 before_install:
   - gem install bundler
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 <!-- The changes listed above will go below when a new release is being prepared. -->
 
 - Add explicit loading of forwardable https://github.com/south37/gcpc/pull/10
+- Add ruby 2.7 as a test target https://github.com/south37/gcpc/pull/12
 
 ## 0.0.6
 


### PR DESCRIPTION
## Why
Want to support ruby 2.7.

## What
Add ruby 2.7 as a test target.