### PR TITLE
Update ruby version to 2.7.2 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.6.6
-  - 2.7.3
+  - 2.7.2
 before_install:
   - gem install bundler
 jobs:


### PR DESCRIPTION
## Why
Ruby 2.7.3 does not exist now.

## What
Update ruby version in CI to 2.7.2.
I also removed Ruby 2.6.6.